### PR TITLE
Project should not be a pandora box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-adw = {package = "libadwaita", rev = "e9ca4b59f2d3774c3ecfbb87828f9c6325fd59f9", git = "https://gitlab.gnome.org/World/Rust/libadwaita-rs.git"}
+adw = {version = "0.1.1", package = "libadwaita"}
 gettext-rs = {version = "0.7", features = ["gettext-system"]}
-gtk = {package = "gtk4", git = "https://github.com/gtk-rs/gtk4-rs.git"}
+gtk = {version = "0.4.7", package = "gtk4"}
 log = "0.4"
 once_cell = "1.9"
 pretty_env_logger = "0.4"


### PR DESCRIPTION
The current Cargo.toml uses the bleeding edge git versions of gtk and libadwaita, which is disencouraged by the gtk-rs book.

Now all same versions of the packages should be retrieved from Crates.io,  which will ensure that the project will be the same regardless of when it was compiled.